### PR TITLE
Fixed Error from: Get-ParameterInfo using .Count

### DIFF
--- a/Tests/Get-ParameterInfo.tests.ps1
+++ b/Tests/Get-ParameterInfo.tests.ps1
@@ -1,0 +1,18 @@
+#Requires -Module @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+BeforeAll {
+    Import-Module "$PSScriptRoot/../PSScriptTools.psm1" -Force # -verbose
+}
+
+Describe 'Get-ParameterInfo' {
+    It "Should Not Compare <_>'s -Count Parameter" -ForEach @(
+        Get-Command 'Get-Random'
+        # You only need to test one case, it either works, or not.
+        # The Hard-coded test is a lot faster, I Kept the query to document why Get-Random was chosen.
+        # Get-Command | Where-Object { $_.Parameters.Keys -contains 'Count' } | Select-Object -First 1
+    ) {
+        {
+            Get-Command $_ | Get-ParameterInfo -ea stop
+        } | Should -Not -Throw -Because 'Key "count" was shadowing the dictionary property'
+    }
+}

--- a/functions/Get-Parameter.ps1
+++ b/functions/Get-Parameter.ps1
@@ -54,8 +54,10 @@ Function Get-ParameterInfo {
         Catch {
             Write-Warning "Failed to find command $command"
         }
-        #keep going if parameters were found
-        if ($data.count -gt 0) {
+
+        # keep going if parameters were found
+        # Explicitly calling base, to prevent .count from being shadowed
+        if ($data.psbase.Count -gt 0) {
             #$data is a hash table
             if ($Parameter) {
                 Write-Verbose "Getting parameter $Parameter"
@@ -67,8 +69,8 @@ Function Get-ParameterInfo {
                 }
             }
             else {
-                Write-Verbose "Getting parameter all non-common parameters"
-                $params = $data.keys | Where-Object {$common -notcontains $_}
+                Write-Verbose 'Getting parameter all non-common parameters'
+                $params = $data.keys | Where-Object { $common -notcontains $_ }
             }
             $count = ($params | Measure-Object).count
             #only keep going if non-common parameters were found
@@ -81,26 +83,26 @@ Function Get-ParameterInfo {
                     $name = $_
                     Write-Verbose "Analyzing $name"
                     $type = $data.item($name).ParameterType
-                    $aliases = $data.item($name).Aliases -join ","
+                    $aliases = $data.item($name).Aliases -join ','
 
                     $sets = $data.item($name).ParameterSets.Keys
                     $IsDynamic = $data.item($name).IsDynamic
                     foreach ($set in $sets) {
 
                         #retrieve parameter attribute class
-                        $attributes = $data.item($name).Attributes | Where-Object {$_ -is [system.management.automation.parameterAttribute] -AND $_.ParameterSetName -eq $set}
+                        $attributes = $data.item($name).Attributes | Where-Object { $_ -is [system.management.automation.parameterAttribute] -AND $_.ParameterSetName -eq $set }
 
                         #a parameter could have different positions in different property sets
                         if ($attributes.position -ge 0) {
                             $position = $attributes.position
                         }
                         else {
-                            $position = "Named"
+                            $position = 'Named'
                         }
 
                         #write a custom object to the pipeline
                         [PSCustomObject]@{
-                            PSTypeName                      = "PSParameterInfo"
+                            PSTypeName                      = 'PSParameterInfo'
                             Name                            = $name
                             Aliases                         = $aliases
                             Mandatory                       = $attributes.mandatory
@@ -125,5 +127,3 @@ Function Get-ParameterInfo {
     } #end
 
 } #end function
-
-


### PR DESCRIPTION
- It explicitly calls `property` `count`, to prevent errors when there is a `key` named `count`
- Fixed #115  Error: `Cannot compare "System.Management.Automation.ParameterMetadata" because it is not IComparable`.
- Created a Pester5 test to confirm it's working
- Converted non-interpolated quotes to single quotes

